### PR TITLE
Fix wp_load_alloptions() returning the wrong assoc array format.

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -278,8 +278,13 @@ function wp_cache_fetch_all() {
  * @param int       $delay  Number of seconds to wait before invalidating the items.
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
-function wp_cache_flush( $delay = 0 ) {	
-	$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
+function wp_cache_flush( $delay = 0 ) {
+	if ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ) {
+		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 )[0];
+	} else {
+		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+		$caller = $caller[0];
+	}
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;

--- a/object-cache.php
+++ b/object-cache.php
@@ -280,7 +280,8 @@ function wp_cache_fetch_all() {
  */
 function wp_cache_flush( $delay = 0 ) {
 	if ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ) {
-		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 )[0];
+		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
+		$caller = $caller[0];
 	} else {
 		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 		$caller = $caller[0];

--- a/object-cache.php
+++ b/object-cache.php
@@ -286,12 +286,11 @@ function wp_cache_flush( $delay = 0 ) {
 		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 		$caller = $caller[0];
 	}
-
-	if ( 'cli' !== php_sapi_name() ) {
+	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;
 	}
-
+	trigger_error( sprintf( 'wp_cache_flush() used, this is broadly not recommended. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 	global $wp_object_cache;
 	return $wp_object_cache->flush( $delay );
 }

--- a/object-cache.php
+++ b/object-cache.php
@@ -1514,12 +1514,12 @@ class WP_Object_Cache {
 			return $this->cache[ $key ];
 		}
 
-		$keys = $this->get( 'alloptionskeys', 'options' );
+		$keys = array_keys( $this->get( 'alloptionskeys', 'options' ) );
 		if ( empty( $keys ) ) {
 			return array();
 		}
 
-		$data = $this->getMulti( array_keys( $keys ), 'options' );
+		$data = $this->getMulti( $keys, 'options' );
 
 		if ( empty( $data ) ) {
 			return array();
@@ -1527,7 +1527,7 @@ class WP_Object_Cache {
 
 		// getMulti returns a map of `[ cache_key => value ]` but we need to
 		// return a map of `[ option_name => value ]`
-		$data = array_combine( array_keys( $keys ), array_values( $data ) );
+		$data = array_combine( $keys, $data );
 
 		$this->cache[ $key ] = $data;
 		return $data;

--- a/object-cache.php
+++ b/object-cache.php
@@ -286,11 +286,12 @@ function wp_cache_flush( $delay = 0 ) {
 		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 		$caller = $caller[0];
 	}
-	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+
+	if ( 'cli' !== php_sapi_name() ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;
 	}
-	trigger_error( sprintf( 'wp_cache_flush() used, this is broadly not recommended. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
+
 	global $wp_object_cache;
 	return $wp_object_cache->flush( $delay );
 }

--- a/object-cache.php
+++ b/object-cache.php
@@ -279,8 +279,7 @@ function wp_cache_fetch_all() {
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
 function wp_cache_flush( $delay = 0 ) {
-	$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
-	$caller = $caller[0];
+	$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;

--- a/object-cache.php
+++ b/object-cache.php
@@ -279,13 +279,8 @@ function wp_cache_fetch_all() {
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
 function wp_cache_flush( $delay = 0 ) {
-	if ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ) {
-		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
-		$caller = $caller[0];
-	} else {
-		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
-		$caller = $caller[0];
-	}
+	$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
+	$caller = $caller[0];
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;

--- a/object-cache.php
+++ b/object-cache.php
@@ -1524,6 +1524,10 @@ class WP_Object_Cache {
 			return array();
 		}
 
+		// getMulti returns a map of `[ cache_key => value ]` but we need to
+		// return a map of `[ option_name => value ]`
+		$data = array_combine( array_keys( $keys ), array_values( $data ) );
+
 		$this->cache[ $key ] = $data;
 		return $data;
 	}

--- a/tests/tests/alloptions.php
+++ b/tests/tests/alloptions.php
@@ -8,11 +8,6 @@ class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
 		$this->assertEquals( array( 'siteurl' => true ), $keys );
 	}
 
-	public function test_wp_load_alloptions_keys() {
-		$options = wp_load_alloptions();
-		$this->assertTrue( isset( $options['siteurl'] ) );
-	}
-
 	public function test_getting_all_options() {
 		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
 
@@ -22,7 +17,9 @@ class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
 
 	public function test_add_option_updates_alloptions_keys() {
 		add_option( 'jordan', 'parise' );
+		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
 		$keys = $this->object_cache->get( 'alloptionskeys', 'options' );
+
 		$this->assertTrue( array_key_exists( 'jordan', $keys ) );
 	}
 }

--- a/tests/tests/alloptions.php
+++ b/tests/tests/alloptions.php
@@ -8,6 +8,11 @@ class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
 		$this->assertEquals( array( 'siteurl' => true ), $keys );
 	}
 
+	public function test_wp_load_alloptions_keys() {
+		$options = wp_load_alloptions();
+		$this->assertTrue( isset( $options['siteurl'] ) );
+	}
+
 	public function test_getting_all_options() {
 		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
 
@@ -17,9 +22,7 @@ class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
 
 	public function test_add_option_updates_alloptions_keys() {
 		add_option( 'jordan', 'parise' );
-		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
 		$keys = $this->object_cache->get( 'alloptionskeys', 'options' );
-
 		$this->assertTrue( array_key_exists( 'jordan', $keys ) );
 	}
 }


### PR DESCRIPTION
wp_load_alloptions() expects the array to be keyed by option names, not cache keys. This breaks deleting options, as WP core expects to be able to unset the deleted option form the alloptions array.