### PR TITLE
Ensure `alloptionskeys` doesn't return false from cache to avoid `array_keys` notice

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1513,7 +1513,13 @@ class WP_Object_Cache {
 			return $this->cache[ $key ];
 		}
 
-		$keys = array_keys( $this->get( 'alloptionskeys', 'options' ) );
+		// On a cold cache, this will be empty and throw a notice if passed to array_keys below
+		$alloptionskeys = $this->get( 'alloptionskeys', 'options' );
+		if ( ! $alloptionskeys ) {
+			return array();
+		}
+
+		$keys = array_keys( $alloptionskeys );
 		if ( empty( $keys ) ) {
 			return array();
 		}


### PR DESCRIPTION
This fixes the following notice on a cold cache:

```
Warning: array_keys() expects parameter 1 to be array, boolean given in /path/to/wp-content/object-cache.php on line 1516
```