### PR TITLE
Fix flag for bypassing local cache

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1311,7 +1311,7 @@ class WP_Object_Cache {
 			else
 				$value = $this->m->get( $derived_key, $cache_cb, $cas_token );
 		} else {
-			if ( isset( $this->cache[$derived_key] ) ) {
+			if ( isset( $this->cache[$derived_key] ) && ! $force ) {
 				$found = true;
 				return is_object( $this->cache[$derived_key] ) ? clone $this->cache[$derived_key] : $this->cache[$derived_key];
 			} elseif ( in_array( $group, $this->no_mc_groups ) ) {


### PR DESCRIPTION
Ran into an interesting issue where I was setting a transient for an oauth 2 token in a long running cli command, token was set to invalidate every 6 minutes but was not invalidating correctly.

When using `wp_cache_get/wp_cache_set`, local cache does not take into account expiry time, so any long running script will always be pulling from local cache despite the fact that the cache entry is no longer valid - Using `$force` on `wp_cache_get` should fix this by forcing a cache server lookup every time we try to access the cache entry. $force flag is currently an unused function param on `$wp_object_cache->get()`

Kinda surprised this hasn't been noticed/fixed before so wondering if there are other knock-on effects caused by the change in this PR which is why it may not have been implemented?



