### PR TITLE
Fix Testing Issue

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -280,7 +280,7 @@ function wp_cache_fetch_all() {
  */
 function wp_cache_flush( $delay = 0 ) {
 	$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
-	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	if ( 'cli' !== php_sapi_name() ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;
 	}


### PR DESCRIPTION
As identified in https://github.com/humanmade/wordpress-pecl-memcached-object-cache/pull/4#pullrequestreview-176007588, the dropin is currently killing any unit test suites that call in HM Platform code because WP uses `wp_cache_flush` on every class shutdown.

This fast-forwards the CLI fix so that test suites can at least run with this dropin.

Note: on line 287 below this we're still throwing a Notice, even though core is doing the cache flushing. Not sure whether we'd want to address that as well or not.