### PR TITLE
Fix passing backtrace array by reference

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -279,7 +279,8 @@ function wp_cache_fetch_all() {
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
 function wp_cache_flush( $delay = 0 ) {
-	$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
+	$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
+	$caller    = array_shift( $backtrace );
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;

--- a/object-cache.php
+++ b/object-cache.php
@@ -279,7 +279,7 @@ function wp_cache_fetch_all() {
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
 function wp_cache_flush( $delay = 0 ) {
-  $backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
+	$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
 	$caller    = array_shift( $backtrace );
 	if ( 'cli' !== php_sapi_name() ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );


### PR DESCRIPTION
When flushing the cache on a PHP 7.0+ machine, a notice is thrown due to passing an array return into `array_shift` each and every time we flush the cache. This is a lot when running a test suite.

This is addressed in #4, but if we'd like to push through a fix for #11 early, we should include this fix here as well since both cause issues within test suites.

```
Client\Analytics\Tests\Test_Cron::test_is_valid_post_item_from_path_no_post
Only variables should be passed by reference
``` 