### PR TITLE
Make "broadly not recommended" cache flush warning filterable

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -285,7 +285,9 @@ function wp_cache_flush( $delay = 0 ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;
 	}
-	trigger_error( sprintf( 'wp_cache_flush() used, this is broadly not recommended. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
+	if ( apply_filters( 'pecl_memcached/warn_on_flush', true ) ) {
+		trigger_error( sprintf( 'wp_cache_flush() used, this is broadly not recommended. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
+	}
 	global $wp_object_cache;
 	return $wp_object_cache->flush( $delay );
 }


### PR DESCRIPTION
In local development environments we frequently need to flush the cache manually after making database or content updates, and many WP-CLI commands (including installation and content imports) call `wp_cache_flush()` automatically after completing their updates.

To avoid verbosely and repeatedly telling developers that the thing they wanted to do in their local is wrong, this PR introduces a filter "pecl_memcached/warn_on_flush" to permit a local environment to hook "__return_false" in to suppress this warning when it is not needed.

I've opened this PR both because I find the repeated warnings make WP-CLI output very hard to read and scan when using this caching integration, and because I've already gotten concerned messages from a client team asking about whether something is wrong when they suddenly started seeing this message when they run quotidian WP-CLI commands.