### PR TITLE
Upgrade travis testing matrix to use PHP 7 & later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
+    - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0


### PR DESCRIPTION
5.3 and other old versions are no longer available on Travis images without additional effort.

The tests still fail, with the message
```
mysqladmin: connect to server at 'localhost' failed
error: 'Can't connect to MySQL server on 'localhost' (111)'
Check that mysqld is running on localhost and that the port is 3306.
You can check this by doing 'telnet localhost 3306'
The command "bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION" failed and exited with 1 during .
```
but this PR at least moves the project closer to being testable in CI once again