### PR TITLE
[FIX] Ensure pass int to Memcached->flush()

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1264,7 +1264,7 @@ class WP_Object_Cache {
 	 * @return  bool                Returns TRUE on success or FALSE on failure.
 	 */
 	public function flush( $delay = 0 ) {
-		$result = $this->m->flush( $delay );
+		$result = $this->m->flush( intval( $delay ) );
 
 		// Only reset the runtime cache if memcached was properly flushed
 		if ( Memcached::RES_SUCCESS === $this->getResultCode() )


### PR DESCRIPTION
When hook `'wp_cache_flush'` to an action without arguments, the first argument passed is `''`. That causes a fatal error when calling `Memcached->flush('')`.
This simple fix prevents that error ensuring pass an integer value.